### PR TITLE
fix: signing psbt with taproot address with okx wallet

### DIFF
--- a/.changeset/long-drinks-search.md
+++ b/.changeset/long-drinks-search.md
@@ -1,0 +1,5 @@
+---
+"@gobob/sats-wagmi": patch
+---
+
+fix: signing psbt with taproot address with okx wallet

--- a/packages/sats-wagmi/src/connectors/okx.ts
+++ b/packages/sats-wagmi/src/connectors/okx.ts
@@ -153,11 +153,14 @@ class OKXConnector extends SatsConnector {
       }
     }
 
+    const addressType = this.getAddressType(this.paymentAddress!);
+
     const toSignInputs = inputs.map((index) => {
       return {
         index,
-        publicKey,
-        disableTweakSigner: this.getAddressType(this.paymentAddress!) !== AddressType.p2tr
+        ...(addressType === AddressType.p2tr
+          ? { address: this.paymentAddress, disableTweakSigner: false }
+          : { publicKey: publicKey, disableTweakSigner: true })
       };
     });
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!
-->

Closes # <!-- Github issue # here -->

## 📝 Description

for taproot address we need to specify address: ${paymentAddress}.

all other combinations seem to not work e.g. address: ${publicKey}, publicKey: ${paymentAddress}. Also specifying both fields address and publicKey results in error.

for some reason not documented anywhere. OKX [documentation](https://www.okx.com/web3/build/docs/sdks/app-connect-bitcoin-ui#signpsbt) tells that we need to specify either of these fields which does not seem to work

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path -->

## 📝 Additional Information